### PR TITLE
Implementing the value(rank) of a card being null

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ BE ON THE LOOKOUT !
 	// Creating a random variable to draw one card
 
 	rand.Seed(time.Now().UTC().UnixNano())
+	
 	// calling in a goroutine to prevent blocking
 	go timedShuffle(cards)
 
@@ -132,6 +133,7 @@ func timedShuffle(cards []deck.Card) {
 	// timer := time.NewTimer(x * time.Second)
 
 	timer := time.NewTicker(time.Second * 2)
+	lastTwoCards := []deck.Card{cards[0], cards[1]}
 
 	for {
 		select {
@@ -146,6 +148,7 @@ func timedShuffle(cards []deck.Card) {
 			lastTwoCards[0] = lastTwoCards[1]
 			// taken the random card to be the most recent one
 			lastTwoCards[1] = card
+
 			checkLastTwoCards(false)
 
 			for index, j := range lastTwoCards {


### PR DESCRIPTION
Currently at the beginning of the game during the first retrieval of the cards, the first card does not display the rank of the cards instead it annotates it to rank(0) .
e.g [ 'Rank(0) of Spades', 'King of Hearts' ] is the current output instead of [ 'Ace of Spades', 'King of Hearts' ]

The issue can be solved through initializing through actually giving the correct indices to the deck of cards  to refer to e.g   	
```
lastTwoCards := []deck.Card{cards[0], cards[1]} 
```
