### PR TITLE
Randomizing the picking of cards only once #issue2

### DIFF
--- a/main.go
+++ b/main.go
@@ -47,14 +47,6 @@ BE ON THE LOOKOUT !
 	}
 	fmt.Println("Gooooo!")
 
-	// Creating a random variable to draw one card
-
-	rand.Seed(time.Now().UTC().UnixNano())
-
-	fmt.Printf("first Card %s \n", cards[0])
-	fmt.Printf("Second Card %s \n", cards[1])
-	fmt.Printf("Last Card %s \n", cards[51])
-
 	// calling in a goroutine to prevent blocking
 	go timedShuffle(cards)
 
@@ -66,7 +58,7 @@ BE ON THE LOOKOUT !
 		}
 
 		fmt.Scanf("%s\n", &input)
-		// fmt.Println(input)
+
 		if input != "" {
 			fmt.Println("SNAP")
 			checkLastTwoCards(true)
@@ -74,9 +66,9 @@ BE ON THE LOOKOUT !
 		}
 
 		input = ""
-		fmt.Println("Players final score is :", score)
 
 	}
+	fmt.Println("Players final score is :", score)
 
 }
 
@@ -118,7 +110,6 @@ func timedShuffle(cards []deck.Card) {
 
 	timer := time.NewTicker(time.Second * 2)
 	lastTwoCards := []deck.Card{cards[0], cards[1]}
-	// done := make(chan bool)
 
 	for {
 		select {
@@ -144,9 +135,6 @@ func timedShuffle(cards []deck.Card) {
 			lastTwoCards[1] = cards[lastCard]
 
 			checkLastTwoCards(false)
-			// case <-done:
-			// 	fmt.Println("Game over! you scored a total of ", score)
-			// 	return
 
 		}
 

--- a/main.go
+++ b/main.go
@@ -55,15 +55,9 @@ BE ON THE LOOKOUT !
 	// calling in a goroutine to prevent blocking
 	go timedShuffle(cards)
 
-	// fmt.Println(cards)
-	// fmt.Println(len(cards))
-	// fmt.Println(drawRandomCard(cards))
 	var input string
 
 	for {
-		if cardsDrawn == 52 {
-			break
-		}
 
 		fmt.Scanf("%s\n", &input)
 		// fmt.Println(input)
@@ -74,9 +68,9 @@ BE ON THE LOOKOUT !
 		}
 
 		input = ""
+		fmt.Println("Players final score is :", score)
 
 	}
-	fmt.Println("Players final score is :", score)
 
 }
 
@@ -92,7 +86,7 @@ func checkLastTwoCards(snap bool) {
 	} else {
 		// Check if the last two cards are the same
 		if lastTwoCards[0] == lastTwoCards[1] {
-			// We are sure the user hasnt snapped so we deduct the score
+
 			score++
 		}
 
@@ -118,34 +112,32 @@ func timedShuffle(cards []deck.Card) {
 
 	timer := time.NewTicker(time.Second * 2)
 	lastTwoCards := []deck.Card{cards[0], cards[1]}
+	// done := make(chan bool)
 
 	for {
 		select {
 		// Waiting for the channel to emit a value
 		case <-timer.C:
-			// recursively call our shuffle
+
 			fmt.Printf("=============================[%2d/%2d]~ \n", lastCard, len(cards))
 			fmt.Println(lastTwoCards[0])
 			fmt.Println(lastTwoCards[1])
 			fmt.Println("============================")
 
-			// go timedShuffle(cards)
 			lastCard++
-			if lastCard >= len(cards) {
 
+			if lastCard >= len(cards) {
 				return
 			}
 
-			// shift position to position one
 			lastTwoCards[0] = lastTwoCards[1]
 
 			lastTwoCards[1] = cards[lastCard]
 
-			// taken the random card to be the most recent one
-
 			checkLastTwoCards(false)
 
 		}
+
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -13,7 +13,6 @@ import (
 // Holds the last two cards that will be displayed to the user
 var lastTwoCards [2]deck.Card
 var score = 0
-var cardsDrawn = 0
 var lastCard = 1
 
 func main() {
@@ -52,12 +51,19 @@ BE ON THE LOOKOUT !
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
+	fmt.Printf("first Card %s \n", cards[0])
+	fmt.Printf("Second Card %s \n", cards[1])
+	fmt.Printf("Last Card %s \n", cards[51])
+
 	// calling in a goroutine to prevent blocking
 	go timedShuffle(cards)
 
 	var input string
 
 	for {
+		if lastCard >= 51 {
+			break
+		}
 
 		fmt.Scanf("%s\n", &input)
 		// fmt.Println(input)
@@ -119,7 +125,7 @@ func timedShuffle(cards []deck.Card) {
 		// Waiting for the channel to emit a value
 		case <-timer.C:
 
-			fmt.Printf("=============================[%2d/%2d]~ \n", lastCard, len(cards))
+			fmt.Printf("=============================[%2d/%2d]~ \n", lastCard+1, len(cards))
 			fmt.Println(lastTwoCards[0])
 			fmt.Println(lastTwoCards[1])
 			fmt.Println("============================")
@@ -127,7 +133,10 @@ func timedShuffle(cards []deck.Card) {
 			lastCard++
 
 			if lastCard >= len(cards) {
+				// // fmt.Println("Game Over!")
+				// done <- true
 				return
+
 			}
 
 			lastTwoCards[0] = lastTwoCards[1]
@@ -135,6 +144,9 @@ func timedShuffle(cards []deck.Card) {
 			lastTwoCards[1] = cards[lastCard]
 
 			checkLastTwoCards(false)
+			// case <-done:
+			// 	fmt.Println("Game over! you scored a total of ", score)
+			// 	return
 
 		}
 

--- a/main.go
+++ b/main.go
@@ -3,24 +3,23 @@ package main
 import (
 	"fmt"
 
-	"github.com/oyugirachel/deck"
 	"github.com/common-nighthawk/go-figure"
+	"github.com/oyugirachel/deck"
 
 	"math/rand"
 	"time"
-
-	
 )
 
 // Holds the last two cards that will be displayed to the user
 var lastTwoCards [2]deck.Card
 var score = 0
 var cardsDrawn = 0
+var lastCard = 1
 
 func main() {
 	cards := deck.New(deck.Deck(1), deck.Shuffle)
 	// Game instructions
-	art :=figure.NewColorFigure("SNAP GAME", "", "Red", true)
+	art := figure.NewColorFigure("SNAP GAME", "", "Red", true)
 	art.Blink(3000, 500, -1)
 
 	art.Print()
@@ -43,8 +42,8 @@ BE ON THE LOOKOUT !
 
 `
 	fmt.Println(message)
-	for k:=6; k>0; k--{
-		fmt.Printf("%d ..",k)
+	for k := 6; k > 0; k-- {
+		fmt.Printf("%d ..", k)
 		time.Sleep(time.Second)
 	}
 	fmt.Println("Gooooo!")
@@ -52,7 +51,7 @@ BE ON THE LOOKOUT !
 	// Creating a random variable to draw one card
 
 	rand.Seed(time.Now().UTC().UnixNano())
-	
+
 	// calling in a goroutine to prevent blocking
 	go timedShuffle(cards)
 
@@ -65,7 +64,7 @@ BE ON THE LOOKOUT !
 		if cardsDrawn == 52 {
 			break
 		}
-		
+
 		fmt.Scanf("%s\n", &input)
 		// fmt.Println(input)
 		if input != "" {
@@ -102,21 +101,6 @@ func checkLastTwoCards(snap bool) {
 
 }
 
-// DrawRandomCard function
-func drawRandomCard(cards []deck.Card) deck.Card {
-
-	// Generates a random card position between 0 and the length of the cards
-	var cardPosition = rand.Intn(len(cards))
-	// increment cards drawn
-	cardsDrawn++
-	
-	// fmt.Println(cardPosition)
-	// Returning the random chosen card
-
-	return cards[cardPosition]
-
-}
-
 // randInt function to randomize time between max and min
 func randInt(min int, max int) int {
 	return min + rand.Intn(max-min)
@@ -140,31 +124,26 @@ func timedShuffle(cards []deck.Card) {
 		// Waiting for the channel to emit a value
 		case <-timer.C:
 			// recursively call our shuffle
+			fmt.Printf("=============================[%2d/%2d]~ \n", lastCard, len(cards))
+			fmt.Println(lastTwoCards[0])
+			fmt.Println(lastTwoCards[1])
+			fmt.Println("============================")
 
 			// go timedShuffle(cards)
+			lastCard++
+			if lastCard >= len(cards) {
 
-			card := drawRandomCard(cards)
+				return
+			}
+
 			// shift position to position one
 			lastTwoCards[0] = lastTwoCards[1]
+
+			lastTwoCards[1] = cards[lastCard]
+
 			// taken the random card to be the most recent one
-			lastTwoCards[1] = card
 
 			checkLastTwoCards(false)
-
-			for index, j := range lastTwoCards {
-				
-				if index == 0 { //If the value is first one
-					fmt.Println("=====================================")
-					fmt.Printf("[ '%v', ", j)
-					
-				} else if len(lastTwoCards) == index+1 { // If the value is the last one
-					fmt.Printf("'%v' ] \n", j)
-					fmt.Println("======================================")
-				} else {
-					fmt.Printf(" '%v', ", j) // for all ( middle ) values
-				}
-				
-			}
 
 		}
 	}


### PR DESCRIPTION
Currently the logic imposed shuffles a deck of cards randomly even after reshuffling it previously, this is against the game logic and rules for a deck can only be shuffled once and cards to be picked one after the other without continuous random shuffling,
e.g when my last card is Ace of spades, Seven of Kings, logically the next card should be Seven of kings and another card drawn from the deck .
A good solution could be deleting the present  drawrandomcards function which randomly picks the cards from our present deck continuously