### PR TITLE
Add .env to .gitignore to prevent secret exposure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+# Environment files — added by ZenVeil
+.env
+.env.*


### PR DESCRIPTION
## ZenVeil Security Fix — `.env` not in `.gitignore`

Environment files (`.env`, `.env.*`) often contain API keys, database credentials, and other secrets.
Without a `.gitignore` entry they can be accidentally committed to the repository.

**This PR adds `.env` and `.env.*` to `.gitignore`.**

> If a `.env` file has already been committed, also run:
> ```bash
> git rm --cached .env
> git commit -m 'Stop tracking .env'
> ```
> and rotate any credentials that were in that file.

---
_Opened by [ZenVeil](https://zenveil.dev) • Automated Security Scanning_